### PR TITLE
Directly ack empty stream messages

### DIFF
--- a/project/Common.scala
+++ b/project/Common.scala
@@ -1,6 +1,6 @@
 import org.scalafmt.sbt.ScalafmtPlugin
 import org.scalafmt.sbt.ScalafmtPlugin.autoImport._
-import sbt.Keys.{logBuffered, _}
+import sbt.Keys._
 import sbt._
 
 object Common {
@@ -25,7 +25,7 @@ object Common {
         .settings(
           organization := "io.kensu",
           name := "redis-streams-zio",
-          scalaVersion := "3.1.0",
+          scalaVersion := "3.1.1",
           version := "1.0.0-SNAPSHOT",
           scalacOptions ++= commonScalacOptions,
           Compile / console / scalacOptions --= Seq("-Werror"),

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -10,16 +10,16 @@ object Dependencies {
   val zio = Seq(
     "dev.zio" %% "zio"                 % Version.zio,
     "dev.zio" %% "zio-streams"         % Version.zio,
-    "dev.zio" %% "zio-logging-slf4j"   % "0.5.13",
+    "dev.zio" %% "zio-logging-slf4j"   % "0.5.14",
     "dev.zio" %% "zio-config-typesafe" % Version.zioConfig,
     "dev.zio" %% "zio-config-magnolia" % Version.zioConfig,
     "dev.zio" %% "zio-test-sbt"        % Version.zio % Test
   )
 
-  val redisson = Seq("org.redisson" % "redisson" % "3.16.4")
+  val redisson = Seq("org.redisson" % "redisson" % "3.16.8")
 
   val logback = Seq(
-    "ch.qos.logback" % "logback-classic"  % "1.2.6",
-    "org.slf4j"      % "log4j-over-slf4j" % "1.7.32"
+    "ch.qos.logback" % "logback-classic"  % "1.2.10",
+    "org.slf4j"      % "log4j-over-slf4j" % "1.7.36"
   )
 }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.5.5
+sbt.version = 1.6.2


### PR DESCRIPTION
It turns out if you trim `pending` message in a Redis stream, the message is kept but only its value is removed.

It required two things:
- a [fix in Redisson](https://github.com/redisson/redisson/issues/3880) introduced in 3.16.4
- change from this PR to directly acknowledge and skip additional processing of such empty message